### PR TITLE
Change signature of `Authorize` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Stupidly simple authorization engine.
 
+```
+go get -u github.com/tesladodger/authngn
+```
+
 ## Usage
 
 Register the rules:

--- a/authngn.go
+++ b/authngn.go
@@ -46,6 +46,13 @@ func (n *Authngn) Authorize(ent any, action string, res any) (bool, error) {
 	return auth(ent, res), nil
 }
 
+// Contains returns true if a rule that matches the given criteria has been
+// registered.
+func (n *Authngn) Contains(ent any, action string, res any) bool {
+	_, ok := n.rules[ruleId(ent, action, res)]
+	return ok
+}
+
 // ruleId returns a unique identifier for the action and types of ent and res.
 func ruleId(ent any, action string, res any) string {
 	return strings.Join([]string{

--- a/authngn.go
+++ b/authngn.go
@@ -10,6 +10,7 @@ import (
 // true if the action should be authorized.
 type AuthFunc func(ent, res any) bool
 
+// Authngn contains the methods to register and evaluate authorization rules.
 type Authngn struct {
 	rules map[string]AuthFunc
 }

--- a/authngn.go
+++ b/authngn.go
@@ -1,7 +1,6 @@
 package authngn
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 )
@@ -36,15 +35,14 @@ func (n *Authngn) Register(ent any, action string, res any, f AuthFunc) {
 }
 
 // Authorize evaluates the rule for the given parameters.
-// It returns an error if there is no such rule.
-func (n *Authngn) Authorize(ent any, action string, res any) (bool, error) {
+// It returns false if there is no such rule.
+func (n *Authngn) Authorize(ent any, action string, res any) bool {
 	auth, ok := n.rules[ruleId(ent, action, res)]
 	if !ok {
-		return false,
-			fmt.Errorf("no rule found for %v", ruleId(ent, action, res))
+		return false
 	}
 
-	return auth(ent, res), nil
+	return auth(ent, res)
 }
 
 // Contains returns true if a rule that matches the given criteria has been

--- a/authngn.go
+++ b/authngn.go
@@ -22,6 +22,9 @@ func New() *Authngn {
 // Register adds a new rule to the engine.
 // A previously registered rule matching the same criteria will be replaced.
 //
+// Only the underlying types of ent and res are used: registering User{} is
+// equivalent to registering &User{}.
+//
 // The action can be a set of actions, separated by a comma:
 // `read,write,delete`
 func (n *Authngn) Register(ent any, action string, res any, f AuthFunc) {

--- a/authngn_test.go
+++ b/authngn_test.go
@@ -39,12 +39,15 @@ func TestAuthorize(t *testing.T) {
 		{"aoeusnt", "write", testtype{owner: "aoeusnth"}, false},
 		{"aoeusnth", "delete", testtype{owner: "aoeusnth"}, true},
 		{"aoeusnt", "delete", testtype{owner: "aoeusnth"}, false},
+		{123, "write", "aoeusnth", false},
+		{testtype{id: id}, "create", testtype{owner: id}, false},
 	}
 
 	for i, tc := range testcases {
-		res, err := ngn.Authorize(tc.ent, tc.action, tc.res)
-		assert.NoError(t, err, "failed on test case %d", i)
-		assert.Equal(t, tc.result, res, "failed on test case %d", i)
+		assert.Equal(t,
+			tc.result,
+			ngn.Authorize(tc.ent, tc.action, tc.res),
+			"failed on test case %d", i)
 	}
 }
 

--- a/authngn_test.go
+++ b/authngn_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testtype struct {
@@ -45,6 +46,29 @@ func TestAuthorize(t *testing.T) {
 		assert.NoError(t, err, "failed on test case %d", i)
 		assert.Equal(t, tc.result, res, "failed on test case %d", i)
 	}
+}
+
+func TestContains(t *testing.T) {
+	ngn := New()
+	require.False(t, ngn.Contains(testtype{}, "read", ""))
+	require.False(t, ngn.Contains(testtype{}, "write", ""))
+	require.False(t, ngn.Contains(testtype{}, "delete", ""))
+
+	ngn.Register(&testtype{}, "delete", "", func(_, _ any) bool {
+		return true
+	})
+
+	require.False(t, ngn.Contains(testtype{}, "read", ""))
+	require.False(t, ngn.Contains(testtype{}, "write", ""))
+	require.True(t, ngn.Contains(testtype{}, "delete", ""))
+
+	ngn.Register(&testtype{}, "read,write", testtype{}, func(_, _ any) bool {
+		return true
+	})
+
+	require.True(t, ngn.Contains(testtype{}, "read", testtype{}))
+	require.True(t, ngn.Contains(testtype{}, "write", testtype{}))
+	require.False(t, ngn.Contains(testtype{}, "delete", testtype{}))
 }
 
 func TestKey(t *testing.T) {


### PR DESCRIPTION
Return false if there is no rule that matches the criteria, instead of
returning an error.
This moves some responsibility away from the authngn, while also
simplifying the client.

Other changes are improvements to the documentation.